### PR TITLE
Background covers page and automatically resizes on height change

### DIFF
--- a/src/components/Containers/DesktopContainer.jsx
+++ b/src/components/Containers/DesktopContainer.jsx
@@ -46,13 +46,13 @@ class DesktopContainer extends Component {
     const segmentStyles = {};
     if (background.image) {
       segmentStyles.background = `linear-gradient(${background.overlay}, ${background.overlay}),
-      url(${background.image}) no-repeat`;
+      url(${background.image}) center / cover no-repeat`;
     }
     if (background.fullHeight) {
-      segmentStyles.minHeight = window.innerHeight;
+      segmentStyles.minHeight = `100vh`;
     }
     if (background.halfHeight) {
-      segmentStyles.minHeight = window.innerHeight / 2;
+      segmentStyles.minHeight = `50vh`;
     }
 
     return (

--- a/src/components/Containers/DesktopContainer.jsx
+++ b/src/components/Containers/DesktopContainer.jsx
@@ -49,10 +49,10 @@ class DesktopContainer extends Component {
       url(${background.image}) center / cover no-repeat`;
     }
     if (background.fullHeight) {
-      segmentStyles.minHeight = `100vh`;
+      segmentStyles.minHeight = '100vh';
     }
     if (background.halfHeight) {
-      segmentStyles.minHeight = `50vh`;
+      segmentStyles.minHeight = '50vh';
     }
 
     return (


### PR DESCRIPTION
Background image for a page covers the page rather than sitting in the middle on higher resolution viewports.

Also now changes height automatically rather than on a page reload.