### PR TITLE
fix: add browserlistrc to unify supported browsers list

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,7 @@
 {
   "presets": [
     ["@babel/preset-env", {
-      "modules": false,
-      "targets": {
-        "browsers": [
-          "last 2 versions",
-          "ie >= 11",
-          "safari >= 10"
-        ]
-      }
+      "modules": false
     }],
     "@babel/react"
   ],

--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,0 +1,4 @@
+> 0.25%
+not ie <= 8
+not dead
+not op_mini all

--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -12,12 +12,6 @@ const isDev = process.env.NODE_ENV === 'development'
 const shouldUseRelativeAssetPaths = paths.servedPath === './'
 // Options for autoPrefixer
 const autoprefixerOptions = {
-  browsers: [
-    '>1%',
-    'last 4 versions',
-    'Firefox ESR',
-    'not ie < 9', // React doesn't support IE8 anyway
-  ],
   flexbox: 'no-2009',
 }
 // Note: defined here because it will be used more than once.
@@ -181,7 +175,7 @@ module.exports = {
           }
         ]
       },
-      { 
+      {
         test: /\.css$/,
         loader: "style-loader!css-loader"
       },


### PR DESCRIPTION
unify browsers list
Reason behind removing last 2 versions: https://jamie.build/last-2-versions