### PR TITLE
Fixed mailto links in contact page

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -6,13 +6,13 @@ If you have any questions, suggestions, or anything else, don't hesitate to get 
 
 ## How to contact us
 
- - **If you're a member of HackSoc**, the best way to get in contact with us is through our Discord server. Either send a message into one of the text channels, raise a support ticket, or feel free to directly message a member of committee. You can also email us at [mailto:committee@hacksocnotts.co.uk](committee@hacksocnotts.co.uk), but replies will likely be slower.
+ - **If you're a member of HackSoc**, the best way to get in contact with us is through our Discord server. Either send a message into one of the text channels, raise a support ticket, or feel free to directly message a member of committee. You can also email us at [committee@hacksocnotts.co.uk](mailto:committee@hacksocnotts.co.uk), but replies will likely be slower.
 
- - **If you're not a member**, the best way to contact us is through email. Our committee email address is [mailto:committee@hacksocnotts.co.uk](committee@hacksocnotts.co.uk), or you may email our President directly at [mailto:zac.garby@hacksocnotts.co.uk](zac.garby@hacksocnotts.co.uk).
+ - **If you're not a member**, the best way to contact us is through email. Our committee email address is [committee@hacksocnotts.co.uk](mailto:committee@hacksocnotts.co.uk), or you may email our President directly at [zac.garby@hacksocnotts.co.uk](mailto:zac.garby@hacksocnotts.co.uk).
 
 ## Want to speak for us?
 
-Do you have a talk or a workshop that you would like to deliver to HackSoc members? That's great! We're always looking for guest speakers. Please send us an email at [mailto:committee@hacksocnotts.co.uk](committee@hacksocnotts.co.uk), giving us a quick summary of what your talk is about. Note, we need at minimum four weeks notice, to get things sorted internally, so please let us know as far in advance as possible!
+Do you have a talk or a workshop that you would like to deliver to HackSoc members? That's great! We're always looking for guest speakers. Please send us an email at [committee@hacksocnotts.co.uk](mailto:committee@hacksocnotts.co.uk), giving us a quick summary of what your talk is about. Note, we need at minimum four weeks notice, to get things sorted internally, so please let us know as far in advance as possible!
 
 We're flexible with timings&mdash;ideally a guest talk or workshop would take place at 7pm on a Tuesday or a Thursday, but this is not set in stone. Also, while we generally prefer speakers delivering talks in person, our members are also interested in virtual talks.
 


### PR DESCRIPTION
I'm not a member of the society yet but I will be in a few weeks, I just saw this little mistake on the website and figured I'd fix it rather than make someone else do it.