### PR TITLE
Attempt to fix the ics file

### DIFF
--- a/layouts/events/section.ics
+++ b/layouts/events/section.ics
@@ -5,7 +5,7 @@ CALSCALE:GREGORIAN
 BEGIN:VEVENT
 {{ if not (isset .Params "h") }}
 SUMMARY:{{ .Title }}
-DESCRIPTION:{{ trim (.Content | plainify) "\n" }} More details can be found at {{ .Site.Params.LiveSiteUrl }}{{ .Permalink }}
+DESCRIPTION:{{ replace (trim (.Content | plainify | htmlUnescape) "\n" ) "\n" "\\n\n " }} \nMore details can be found at {{ .Permalink }}
 DTSTART;TZID=Europe/London:{{ dateFormat "20060102T150405" .Params.Start }}
 DTEND;TZID=Europe/London:{{ dateFormat "20060102T150405" .Params.End }}
 {{ if .Params.Adr }}LOCATION:{{ .Params.adr.street_address }}, {{ .Params.adr.locality }}, {{ .Params.adr.country_name }}{{ end }}


### PR DESCRIPTION
In order of what's on line 8:
 * Added a replace for "\n" → "\\n\n ". Looking at other .ics files, it seems like you have to add a space at the beginning of any new lines in the description, and that the new lines are only for aesthetics, so I added an actual \n (well, \\n so it survives formatting). I think this is the main fix - the parsers probably thought everything upto the : in the URL was a tag like DESCRIPTION and getting really confused
 * Piped the plain output through htmlUnescape - to fix any &rsquo; and whatnot (this isn't a html file so any tags should be ignored by whatever is reading it)
 * Added a newline before “More” in “More details can be found at ...”. Because I think it'll look nicer on a new line rather than a wall of text.
 * Removed {{ .Site.Params.LiveSiteUrl }}. That seems to only give <no value> in the output (may also need to fix line 17)

 * Also I added a newline at the end of the file because that's how my editor was set and I can't be bothered to change it and it seems fine anyway

btw I tested it in the import screen of Thunderbird, before it was saying there were no events found, now it lists them