### PR TITLE
Add committee page to main header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <header>
 	<a href="{{ .Site.BaseURL }}">
-		<img src="/img/logo.svg" height="125px" alt="HackSoc">
+		<img src="/img/logo.svg" height="150px" alt="HackSoc">
 	</a>
 	<div class="divider"></div>
 	<nav>
@@ -8,6 +8,7 @@
 			<li><a href="https://www.su.nottingham.ac.uk/societies/society/hack/" class="large">JOIN US!</a></li>
 			<li><a href="/calendar">Calendar</a></li>
 			<li><a href="https://hacknotts.com/">HackNotts</a></li>
+			<li><a href="/committee">Committee</a></li>
 			<li><a href="/contact">Contact Us</a></li>
 		</ul>
 	</nav>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -55,7 +55,7 @@ header {
 
 header div.divider {
     display: inline-block;
-    height: 125px;
+    height: 150px;
     width: 2px;
     border: none;
     background-color: #3d3d3d;


### PR DESCRIPTION
This PR adds a link to the committee page, since it should be more prevalent than a tiny link in the footer.

![Screenshot of the new nav header](https://github.com/HackSocNotts/hacksocnotts.github.io/assets/44349936/40fdc5fe-6a72-463d-b28c-b70316820c6f)
