### PR TITLE
Remove the / from Hacknotts 2021’s date to avoid an error

### DIFF
--- a/content/events/2022-02-12-hacknotts.md
+++ b/content/events/2022-02-12-hacknotts.md
@@ -1,6 +1,6 @@
 ---
 title: "HackNotts 2021"
-date: "2022-02-12/13"
+date: "2022-02-12"
 time: "9am to 2pm the following day"
 start: "2022-02-12T09:00:00+00:00"
 end: "2022-02-13T14:00:00+00:00"


### PR DESCRIPTION
…with the latest Hugo

Latest version is 0.152.2 right now.

Also I've realised it doesn't even show up in Hugo 0.122 anyway which is what the website is using.